### PR TITLE
fix: banner text wrapping

### DIFF
--- a/src/components/shared/banner/banner.tsx
+++ b/src/components/shared/banner/banner.tsx
@@ -21,9 +21,13 @@ function Banner({ title, linkText, linkUrl }: BannerProps) {
           prefetch={false}
           arrowTheme="blue"
         >
-          <span className="shrink truncate xs:w-full xs:text-wrap xs:text-center">{title}</span>
+          <span className="shrink truncate xs:w-full xs:whitespace-normal xs:text-center">
+            {title}
+          </span>
           <span className="mx-3.5 h-4 w-px bg-white/10 xs:hidden" aria-hidden />
-          <span className="shrink truncate font-semibold xs:ml-1">{linkText}</span>
+          <span className="shrink truncate font-semibold xs:ml-1 xs:whitespace-normal">
+            {linkText}
+          </span>
         </Link>
       </div>
     </div>

--- a/src/components/shared/header/header.tsx
+++ b/src/components/shared/header/header.tsx
@@ -60,7 +60,7 @@ function Header() {
             />
           </Link>
           <nav
-            className="lg:translate-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 lg:relative lg:inset-0 lg:ml-16 lg:translate-x-0 lg:translate-y-0"
+            className="lg:translate-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 lg:relative lg:bottom-0 lg:left-0 lg:right-0 lg:top-0 lg:ml-16 lg:translate-x-0 lg:translate-y-0"
             aria-label="Global"
           >
             <ul className="flex gap-x-7 md:hidden">


### PR DESCRIPTION
In this PR we add supporting some banner and burder-menu styles on prev ios versions