### PR TITLE
fix: hiding mobile menu, axeptio zindex, button size adjustments

### DIFF
--- a/src/app/(website)/layout.tsx
+++ b/src/app/(website)/layout.tsx
@@ -66,6 +66,9 @@ async function RootLayout({ children }: { children: React.ReactNode }) {
 
                 void 0 === window._axcb && (window._axcb = []);
                 window._axcb.push(function (axeptio) {
+                  axeptio.on("ready", function() {
+                    document.querySelector("div#axeptio_overlay").style.zIndex = "30";
+                  });
                   axeptio.on("cookies:complete", function (choices) {
                     if (choices.hotjar) {
                       loadHotjar();

--- a/src/components/pages/enterprise/hero/hero.tsx
+++ b/src/components/pages/enterprise/hero/hero.tsx
@@ -36,7 +36,7 @@ export default function Hero() {
         </Button>
         <div className="relative mx-auto mt-16 flex w-full max-w-[960px] justify-between overflow-hidden rounded-lg bg-gradient-grey-10 pl-[32px] lg:items-center lg:gap-x-[32px] lg:pb-3 md:mt-[60px] md:max-w-[832px] md:gap-x-[50px] md:pb-0 sm:mt-[52px] sm:flex-col sm:items-start sm:pl-6">
           <span className="rounded-297px absolute right-[50%] top-0 z-[2] h-[60px] w-full max-w-[297px] translate-x-[50%] bg-shadow-red blur-[100px]" />
-          <div className="mb-8 mt-8 w-full max-w-[321px] text-start md:max-w-[244px] sm:mb-7 sm:mt-6 sm:max-w-[272px]">
+          <div className="mb-8 mt-8 w-full max-w-[321px] text-start md:max-w-[244px] sm:mb-7 sm:mt-6 sm:max-w-none sm:pr-6">
             <DesignIcon className="h-8 w-8 sm:h-5 sm:w-5" alt="Hero-image.jpg" />
             <h2 className="pt-6 text-20 font-medium leading-dense tracking-tight lg:text-18 sm:pt-3 sm:text-16 sm:leading-normal sm:tracking-normal">
               Ease of use: Taipy Designer
@@ -47,7 +47,7 @@ export default function Hero() {
               single line of code
             </p>
           </div>
-          <div className="relative flex w-full max-w-[511px] items-end lg:max-w-[490px] sm:pb-2">
+          <div className="relative flex w-full max-w-[511px] items-end lg:max-w-[490px] sm:max-w-none sm:pb-2">
             <Image className="object-contain sm:hidden" src={HeroPlug} alt="" priority />
             <Image
               className="hidden object-contain sm:block"
@@ -58,8 +58,8 @@ export default function Hero() {
             <div className="absolute left-[55%] top-1/2 flex h-[80px] w-full max-w-[219px] -translate-x-1/2 -translate-y-1/2 items-center justify-center md:left-[45%] md:top-[48%] md:max-w-[129px] sm:top-[39%]">
               <span className="absolute h-[80px] w-full rounded-[46px] bg-black blur-[24px]" />
               <Button
-                className="z-[2] flex w-full max-w-[187px] items-center justify-center gap-[11px] border-orange-1 px-0 tracking-snug md:h-[33px]"
-                size="lg"
+                className="z-[2] flex w-full max-w-[187px] items-center justify-center gap-[11px] border-orange-1 tracking-snug lg:h-11 lg:max-w-[172px] lg:text-14 md:h-[33px] md:text-11"
+                size="lgConst"
                 theme="red-outline"
                 href="https://www.youtube.com/watch?v=y3VPT6IPvC4"
                 target="_blank"

--- a/src/components/shared/mobile-menu/mobile-menu.tsx
+++ b/src/components/shared/mobile-menu/mobile-menu.tsx
@@ -139,6 +139,7 @@ function MobileMenu({
                   theme="white-filled"
                   size="lgConst"
                   href={ROUTES.ENTERPRISE}
+                  onClick={hideMobileMenu}
                 >
                   Enterprise
                 </Button>


### PR DESCRIPTION
- hiding mobile menu after eneterprise btn clicking at the mobile menu
- hiding axeptio btn while mobile menu is open
- size on adaptives for `Watch the video btn` on Enterprise page
- little changes of mobile adaptive for hero section on Enterprise page