### PR TITLE
feat: add designer privacy policy

### DIFF
--- a/src/app/(website)/taipy-designer-evaluation-license-agreement/page.tsx
+++ b/src/app/(website)/taipy-designer-evaluation-license-agreement/page.tsx
@@ -1,0 +1,89 @@
+import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import Content from '@/components/pages/article/content';
+import Navigation from '@/components/pages/legal/navigation';
+
+import { getAnchorFromText } from '@/lib/get-anchor-from-text';
+import { DEFAULT_IMAGE_PATH, getMetadata } from '@/lib/get-metadata';
+import { portableToPlain } from '@/lib/portable-to-plain';
+import { getLegalPageBySlug } from '@/lib/sanity/client';
+import { urlForImage } from '@/lib/sanity/image';
+
+export default async function PrivacyPolicy() {
+  const post = await getLegalPageBySlug('taipy-designer-evaluation-license-agreement');
+
+  if (!post) {
+    notFound();
+  }
+
+  const { title, contentRaw } = post;
+
+  const navItems = contentRaw
+    .filter((item) => item.style === 'h3')
+    .map((item) => {
+      if (item._type !== 'block' || !item.children) {
+        return {
+          title: '',
+          anchor: '',
+          level: '',
+        };
+      }
+
+      return {
+        title: (item.children as { text: string }[])[0].text,
+        anchor: getAnchorFromText((item.children as { text: string }[])[0].text),
+        level: item.style as string,
+      };
+    });
+
+  return (
+    <>
+      <article className="pb-[148px] pt-[140px] xl:pb-32 xl:pt-[120px] md:pb-[96px] md:pt-[112px] sm:pb-[80px] sm:pt-[92px]">
+        <div className="container relative grid max-w-[1472px] grid-cols-[224px_896px_224px] gap-x-16 xl:block xl:max-w-[896px]">
+          {navItems.length > 0 && (
+            <div className="absolute col-start-1 col-end-1 h-full max-w-[224px] xl:static xl:mt-12 xl:h-auto xl:max-w-none md:mt-10 sm:mt-8">
+              <Navigation items={navItems} currentAnchorGarPx={60} />
+            </div>
+          )}
+          <div className="col-start-2 col-end-2 mt-14 xl:mt-7 md:mt-6 sm:mt-5">
+            <h1 className="font-title md:text-30 text-40 font-semibold leading-tight tracking-tight lg:text-36">
+              {title}
+            </h1>
+            {/* TODO: add datePicker in sanity for that */}
+            {/* <p className="text-gray-40 mt-4 text-18 font-light leading-relaxed tracking-tighter lg:leading-tight sm:mt-3">
+              Last Updated: {lastUpdateDate}
+            </p> */}
+            <Content className="mt-12 lg:mt-10 md:mt-9" content={contentRaw} />
+          </div>
+        </div>
+      </article>
+    </>
+  );
+}
+
+export async function generateMetadata(): Promise<Metadata | null> {
+  const post = await getLegalPageBySlug('taipy-designer-evaluation-license-agreement');
+
+  if (!post) {
+    return null;
+  }
+
+  const { contentRaw, title, seo } = post;
+
+  const description =
+    seo?.metaDescription || `${portableToPlain(contentRaw).split('.')[0].slice(0, 159)}…`;
+
+  const image = seo?.socialImage || null;
+
+  const imagePath = image ? urlForImage(image).width(1200).height(630).url() : DEFAULT_IMAGE_PATH;
+
+  return getMetadata({
+    title: seo?.metaTitle || title,
+    description,
+    pathname: `/taipy-designer-evaluation-license-agreement`,
+    imagePath,
+  });
+}
+
+export const revalidate = 60;

--- a/src/components/pages/legal/navigation/navigation.tsx
+++ b/src/components/pages/legal/navigation/navigation.tsx
@@ -18,11 +18,10 @@ interface NavigationItem {
 
 interface NavigationProps {
   items: NavigationItem[];
+  currentAnchorGarPx?: number;
 }
 
-const CURRENT_ANCHOR_GAP_PX = 200;
-
-function Navigation({ items }: NavigationProps) {
+function Navigation({ items, currentAnchorGarPx = 200 }: NavigationProps) {
   const titles = useRef<HTMLElement[]>([]);
   const [currentAnchor, setCurrentAnchor] = useState<string | null>(null);
   const [isOpen, setIsOpen] = useState(false);
@@ -38,7 +37,7 @@ function Navigation({ items }: NavigationProps) {
 
   const updateCurrentAnchor = useCallback(() => {
     const currentTitleIdx = titles.current.findIndex(
-      (anchor) => anchor.getBoundingClientRect().top - CURRENT_ANCHOR_GAP_PX >= 0,
+      (anchor) => anchor.getBoundingClientRect().top - currentAnchorGarPx >= 0,
     );
 
     const idx =

--- a/src/constants/menu.ts
+++ b/src/constants/menu.ts
@@ -83,6 +83,7 @@ export const MENU = {
         items: [
           { label: 'Terms of service', href: ROUTES.TERMS },
           { label: 'Privacy policy', href: ROUTES.PRIVACY },
+          { label: 'Taipy Designer Agreement', href: ROUTES.DESIGNER_LICENSE },
         ],
       },
     ],

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -24,6 +24,7 @@ export const ROUTES: Record<string, URL | Route<string>> = {
   ENTERPRISE: '/enterprise',
   COMMUNITY: '/community',
   DESIGNER: '/designer',
+  DESIGNER_LICENSE: '/taipy-designer-evaluation-license-agreement',
   TERMS: '/terms-of-use', // https://www.taipy.io/legal/terms-of-use
   COMPANY: '/',
   TWITTER: new URL('https://twitter.com/Taipy_io'),


### PR DESCRIPTION
This pull request brings adding new Designer privacy policy page + footer link

**References**
[Preview](https://taipy-website-git-designer-privacy-taipy-team-f9db2bc7.vercel.app/taipy-designer-evaluation-license-agreement)

<details>

<summary>Design</summary>

![image](https://github.com/pixel-point/taipy-next/assets/88053873/15d456e8-bd9b-47ce-baf1-d03267ea7e63)

</details>