### PR TITLE
feat: add related posts section on Home page

### DIFF
--- a/schemas/index.ts
+++ b/schemas/index.ts
@@ -4,6 +4,7 @@ import { category } from './category';
 import { customBlockquote, customNotice, customTable, customYoutube } from './content';
 import { customerStory } from './customer-story';
 import { legal } from './legal';
+import { page } from './page';
 import { post } from './post';
 import { seo } from './seo';
 
@@ -19,4 +20,5 @@ export const schemaTypes = [
   post,
   legal,
   banner,
+  page,
 ];

--- a/schemas/page.ts
+++ b/schemas/page.ts
@@ -16,7 +16,7 @@ export const page = defineType({
     defineField({
       name: 'posts',
       type: 'array',
-      title: 'Chosen Posts',
+      title: 'Related Posts',
       of: [
         {
           type: 'reference',

--- a/schemas/page.ts
+++ b/schemas/page.ts
@@ -23,7 +23,7 @@ export const page = defineType({
           to: [{ type: 'post' }],
         },
       ],
-      validation: (rule: ArrayRule<ReferenceRule>) => rule.min(3),
+      validation: (rule: ArrayRule<ReferenceRule>) => rule.min(3).max(6),
     }),
   ],
 });

--- a/schemas/page.ts
+++ b/schemas/page.ts
@@ -23,7 +23,7 @@ export const page = defineType({
           to: [{ type: 'post' }],
         },
       ],
-      validation: (rule: ArrayRule<ReferenceRule>) => rule.min(3).max(6),
+      validation: (rule: ArrayRule<ReferenceRule>) => rule.min(3).max(3),
     }),
   ],
 });

--- a/schemas/page.ts
+++ b/schemas/page.ts
@@ -1,0 +1,29 @@
+import { DocumentTextIcon } from '@sanity/icons';
+import { ArrayRule, ReferenceRule, StringRule, defineField, defineType } from 'sanity';
+
+export const page = defineType({
+  name: 'page',
+  type: 'document',
+  title: 'Page',
+  icon: DocumentTextIcon,
+  fields: [
+    defineField({
+      name: 'title',
+      type: 'string',
+      title: 'Title',
+      validation: (rule: StringRule) => rule.required(),
+    }),
+    defineField({
+      name: 'posts',
+      type: 'array',
+      title: 'Chosen Posts',
+      of: [
+        {
+          type: 'reference',
+          to: [{ type: 'post' }],
+        },
+      ],
+      validation: (rule: ArrayRule<ReferenceRule>) => rule.min(1),
+    }),
+  ],
+});

--- a/schemas/page.ts
+++ b/schemas/page.ts
@@ -23,7 +23,7 @@ export const page = defineType({
           to: [{ type: 'post' }],
         },
       ],
-      validation: (rule: ArrayRule<ReferenceRule>) => rule.min(1),
+      validation: (rule: ArrayRule<ReferenceRule>) => rule.min(3),
     }),
   ],
 });

--- a/src/app/(website)/page.tsx
+++ b/src/app/(website)/page.tsx
@@ -12,8 +12,11 @@ import RelatedPosts from '@/components/shared/related-posts';
 import Subscribe from '@/components/shared/subscribe';
 
 import { getMetadata } from '@/lib/get-metadata';
+import { getPages } from '@/lib/sanity/client';
 
-function Home() {
+async function Home() {
+  const relatedPosts = await getPages();
+
   return (
     <>
       <Hero />
@@ -29,7 +32,7 @@ function Home() {
       <Integrations />
       <Benefits />
       <Applications />
-      <RelatedPosts />
+      <RelatedPosts relatedPosts={relatedPosts} />
       <CTA />
     </>
   );
@@ -40,3 +43,5 @@ export default Home;
 export async function generateMetadata() {
   return getMetadata(SEO_DATA.INDEX);
 }
+
+export const revalidate = 60;

--- a/src/app/(website)/page.tsx
+++ b/src/app/(website)/page.tsx
@@ -8,6 +8,7 @@ import LargeData from '@/components/pages/home/large-data';
 import Learn from '@/components/pages/home/learn';
 import Optimize from '@/components/pages/home/optimize';
 import CTA from '@/components/shared/CTA';
+import RelatedPosts from '@/components/shared/related-posts';
 import Subscribe from '@/components/shared/subscribe';
 
 import { getMetadata } from '@/lib/get-metadata';
@@ -28,6 +29,7 @@ function Home() {
       <Integrations />
       <Benefits />
       <Applications />
+      <RelatedPosts />
       <CTA />
     </>
   );

--- a/src/components/shared/post-item/post-item.tsx
+++ b/src/components/shared/post-item/post-item.tsx
@@ -44,6 +44,7 @@ export default function PostItem({
               width={648}
               height={364}
               alt={title}
+              quality={85}
               priority={isPriorityLoad}
               placeholder={cover.asset?.metadata?.lqip ? 'blur' : 'empty'}
               blurDataURL={cover.asset?.metadata?.lqip ?? ''}

--- a/src/components/shared/related-posts/index.ts
+++ b/src/components/shared/related-posts/index.ts
@@ -1,0 +1,3 @@
+import RelatedPosts from './related-posts';
+
+export default RelatedPosts;

--- a/src/components/shared/related-posts/related-posts.tsx
+++ b/src/components/shared/related-posts/related-posts.tsx
@@ -15,11 +15,11 @@ async function RelatedPosts({ relatedPosts }: { relatedPosts: SinglePage[] }) {
   return (
     <section className="related mt-[200px] lg:mt-[104px] md:mt-[88px] sm:mt-16">
       <div className="container max-w-7xl">
-        <div className="mb-8 flex items-center justify-between">
+        <div className="mb-8 flex items-end justify-between gap-3">
           <h2 className="text-48 font-semibold leading-dense tracking-tight lg:text-40 md:text-36 sm:text-28">
             See what&apos;s happening at Taipy&apos;s
           </h2>
-          <Link href={ROUTES.BLOG} size="md" theme="white" arrowTheme="red">
+          <Link className="shrink-0" href={ROUTES.BLOG} size="md" theme="white" arrowTheme="red">
             All posts
           </Link>
         </div>

--- a/src/components/shared/related-posts/related-posts.tsx
+++ b/src/components/shared/related-posts/related-posts.tsx
@@ -1,0 +1,33 @@
+import { ROUTES } from '@/constants/routes';
+
+import Link from '@/components/shared/link';
+import PostItem from '@/components/shared/post-item';
+
+import { getPages } from '@/lib/sanity/client';
+
+async function RelatedPosts() {
+  const relatedPosts = await getPages();
+  const allPosts = relatedPosts[0].posts;
+
+  return (
+    <section className="related mt-[200px] lg:mt-[104px] md:mt-[88px] sm:mt-16">
+      <div className="container max-w-7xl">
+        <div className="mb-8 flex items-center justify-between">
+          <h2 className="text-48 font-semibold leading-dense tracking-tight lg:text-40 md:text-36 sm:text-28">
+            See what&apos;s happening at Taipy&apos;s
+          </h2>
+          <Link href={ROUTES.BLOG} size="md" theme="white" arrowTheme="red">
+            All posts
+          </Link>
+        </div>
+        <div className="grid grid-cols-3 gap-x-8 lg:gap-x-6 md:gap-x-5 sm:grid-cols-1 sm:gap-y-7">
+          {allPosts?.map((relatedPost) => (
+            <PostItem key={relatedPost._id} post={relatedPost} isRelated />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default RelatedPosts;

--- a/src/components/shared/related-posts/related-posts.tsx
+++ b/src/components/shared/related-posts/related-posts.tsx
@@ -3,10 +3,13 @@ import { ROUTES } from '@/constants/routes';
 import Link from '@/components/shared/link';
 import PostItem from '@/components/shared/post-item';
 
-import { getPages } from '@/lib/sanity/client';
+import { SinglePage } from '@/types/blog';
 
-async function RelatedPosts() {
-  const relatedPosts = await getPages();
+async function RelatedPosts({ relatedPosts }: { relatedPosts: SinglePage[] }) {
+  if (!relatedPosts || relatedPosts.length === 0) {
+    return null;
+  }
+
   const allPosts = relatedPosts[0].posts;
 
   return (

--- a/src/components/shared/related-posts/related-posts.tsx
+++ b/src/components/shared/related-posts/related-posts.tsx
@@ -20,7 +20,7 @@ async function RelatedPosts() {
             All posts
           </Link>
         </div>
-        <div className="grid grid-cols-3 gap-x-8 lg:gap-x-6 md:gap-x-5 sm:grid-cols-1 sm:gap-y-7">
+        <div className="grid grid-cols-3 gap-x-8 gap-y-9 lg:gap-x-6 md:gap-x-5 sm:grid-cols-1 sm:gap-y-7">
           {allPosts?.map((relatedPost) => (
             <PostItem key={relatedPost._id} post={relatedPost} isRelated />
           ))}

--- a/src/lib/sanity/client.ts
+++ b/src/lib/sanity/client.ts
@@ -1,6 +1,15 @@
 import { GraphQLClient } from 'graphql-request';
 
-import { Category, Legal, Post, SingleCategory, SingleLegal, SinglePost } from '@/types/blog';
+import {
+  Category,
+  Legal,
+  PageQueryResult,
+  Post,
+  SingleCategory,
+  SingleLegal,
+  SinglePage,
+  SinglePost,
+} from '@/types/blog';
 import { CustomerStory, SingleCustomerStory } from '@/types/customer-story';
 import { Banner } from '@/types/shared';
 
@@ -15,9 +24,10 @@ import {
   categoryQuery,
   countCustomerStoryQuery,
   countPostQuery,
-  latestPostsQuery,
   customerStoryQuery,
+  latestPostsQuery,
   legalQuery,
+  pageQuery,
   postQuery,
   promotedPostQuery,
 } from '@/lib/sanity/query';
@@ -134,7 +144,6 @@ export const getRelatedPosts = async ({ postId }: { postId: string }): Promise<P
     .then((data) => data.allPost);
 };
 
-
 export const getLatestPosts = async (): Promise<SinglePost[]> =>
   await graphQLClient
     .request<{ allPost: SinglePost[] }>(latestPostsQuery)
@@ -148,7 +157,6 @@ export const getAllRelatedPosts = async (): Promise<Post[]> => {
     })
     .then((data) => data.allPost);
 };
-
 
 export const getPromotedPost = async (): Promise<Post | null> =>
   await graphQLClient
@@ -207,3 +215,6 @@ export const getBanner = async (): Promise<Banner | null> =>
     .request<{ allBanner: Banner[] }>(bannerQuery)
     .then((data) => data.allBanner)
     .then((data) => data[0] || null);
+
+export const getPages = async (): Promise<SinglePage[]> =>
+  await graphQLClient.request<PageQueryResult>(pageQuery).then((data) => data.allPage);

--- a/src/lib/sanity/query.ts
+++ b/src/lib/sanity/query.ts
@@ -299,3 +299,16 @@ export const bannerQuery = gql`
     }
   }
 `;
+
+export const pageQuery = gql`
+  ${commonPostFieldsFragment}
+  query Page {
+    allPage(limit: 1) {
+      title
+      posts {
+        ...commonPostFields
+        lead
+      }
+    }
+  }
+`;

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -107,3 +107,12 @@ export enum NoticeTypes {
   WARNING = 'warning',
   ATTENTION = 'attention',
 }
+
+export type SinglePage = {
+  title: string;
+  posts: Post[];
+};
+
+export type PageQueryResult = {
+  allPage: SinglePage[];
+};


### PR DESCRIPTION
This pull request brings new related posts section on Home page

**References**
[Preview](https://taipy-website-git-home-update-taipy-team-f9db2bc7.vercel.app/)

<details>

<summary>Design</summary>

![image](https://github.com/pixel-point/taipy-next/assets/88053873/2461449f-74a4-4606-9c09-c89ff47d2087)

</details>